### PR TITLE
fix: Update workflow commands table for env files

### DIFF
--- a/content/actions/using-workflows/workflow-commands-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-commands-for-github-actions.md
@@ -148,12 +148,12 @@ The following table shows which toolkit functions are available within a workflo
 | `core.getState`   | Accessible using environment variable `STATE_{NAME}` |
 | `core.isDebug`    |  Accessible using environment variable `RUNNER_DEBUG` |
 {%- ifversion actions-job-summaries %}
-| `core.summary` | Accessible using environment variable `GITHUB_STEP_SUMMARY` |
+| `core.summary` | Accessible using environment file `GITHUB_STEP_SUMMARY` |
 {%- endif %}
-| `core.saveState`  | {% ifversion actions-save-state-set-output-envs %}Accessible using environment variable `GITHUB_STATE`{% else %}`save-state`{% endif %} |
+| `core.saveState`  | {% ifversion actions-save-state-set-output-envs %}Accessible using environment file `GITHUB_STATE`{% else %}`save-state`{% endif %} |
 | `core.setCommandEcho` | `echo` |
 | `core.setFailed`  | Used as a shortcut for `::error` and `exit 1` |
-| `core.setOutput`  | {% ifversion actions-save-state-set-output-envs %}Accessible using environment variable `GITHUB_OUTPUT`{% else %}`set-output`{% endif %} |
+| `core.setOutput`  | {% ifversion actions-save-state-set-output-envs %}Accessible using environment file `GITHUB_OUTPUT`{% else %}`set-output`{% endif %} |
 | `core.setSecret`  | `add-mask` |
 | `core.startGroup` | `group` |
 | `core.warning`    | `warning` |


### PR DESCRIPTION
### Why:

No issue since it's essentially a typo.

In workflow-commands-for-github-actions.md some rows in toolkit functions/workflow commands table, some rows had "Accessible using environment variable" but should have "Accessible using environment file" as others doing so already had (specifically `core.addPath` and `core.exportVariable`).


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Row description from "Accessible using environment variable ..." to "Accessible using environment file ...".
Changed table rows:
- `core.summary`
- `core.saveState`
- `core.setOutput`

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
